### PR TITLE
Add the ability to tint/modulate a Sprite color

### DIFF
--- a/docs/source/pygamelib.gfx.core.Sprite.rst
+++ b/docs/source/pygamelib.gfx.core.Sprite.rst
@@ -25,12 +25,14 @@ Sprite
       ~Sprite.from_text
       ~Sprite.load
       ~Sprite.load_from_ansi_file
+      ~Sprite.modulate
       ~Sprite.render_to_buffer
       ~Sprite.scale
       ~Sprite.serialize
       ~Sprite.set_sprixel
       ~Sprite.set_transparency
       ~Sprite.sprixel
+      ~Sprite.tint
    
    
 

--- a/tests/test_gfx_core_sprite.py
+++ b/tests/test_gfx_core_sprite.py
@@ -257,6 +257,98 @@ class TestBase(unittest.TestCase):
         self.assertEqual(c.g, 2)
         self.assertEqual(c.b, 3)
 
+    def test_tinting(self):
+        sp = gfx_core.Sprite(
+            sprixels=[
+                [
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                ],
+                [
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                    gfx_core.Sprixel(
+                        " ",
+                        gfx_core.Color(255, 255, 255),
+                        gfx_core.Color(255, 255, 255),
+                    ),
+                ],
+            ]
+        )
+        spr = sp.tint(gfx_core.Color(0, 255, 0), 0.2)
+        self.assertEqual(spr.sprixel(0, 0).bg_color.r, 204)
+        self.assertEqual(spr.sprixel(0, 0).bg_color.g, 255)
+        self.assertEqual(spr.sprixel(0, 0).bg_color.b, 204)
+        # Original sprite should not be modified by tint
+        self.assertEqual(sp.sprixel(0, 0).bg_color.r, 255)
+        self.assertEqual(sp.sprixel(0, 0).bg_color.g, 255)
+        self.assertEqual(sp.sprixel(0, 0).bg_color.b, 255)
+        with self.assertRaises(gfx_core.base.PglInvalidTypeException):
+            sp.tint(gfx_core.Color(0, 255, 0), 1.2)
+        with self.assertRaises(gfx_core.base.PglInvalidTypeException):
+            sp.tint(gfx_core.Color(0, 255, 0), -1.2)
+        with self.assertRaises(gfx_core.base.PglInvalidTypeException):
+            sp.modulate(gfx_core.Color(0, 255, 0), 1.2)
+        with self.assertRaises(gfx_core.base.PglInvalidTypeException):
+            sp.modulate(gfx_core.Color(0, 255, 0), -1.2)
+
+        sp.modulate(gfx_core.Color(0, 255, 0), 0.2)
+        # Original sprite should be modified by modulate
+        self.assertEqual(sp.sprixel(0, 0).bg_color.r, 204)
+        self.assertEqual(sp.sprixel(0, 0).bg_color.g, 255)
+        self.assertEqual(sp.sprixel(0, 0).bg_color.b, 204)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull Request Template

## Description

- Add 2 methods to Sprite: tint() and modulate().
- Add relevant unit tests.
- Add documentation.

tint() : tint a sprite according to a color and a ratio and returns a new sprite.

modulate() : does the same thing than tint() except it returns nothing and update the sprite's sprixels directly instead.


Fixes #143

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local test script
- [x] Local unit tests
- [x] CircleCI

**Test Configuration**:
* OS: Fedora Linux
* OS version: 33
* Python version: 3.9.7
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
