### PR TITLE
Switch to enums instead of int literals for constants

### DIFF
--- a/docs/source/constants.rst
+++ b/docs/source/constants.rst
@@ -9,19 +9,37 @@ General purpose:
 
 * PYGAMELIB_VERSION
 
-.. autoenum:: pygamelib.constants.SizeConstraint
-    :members:
-
 .. autoenum:: pygamelib.constants.Alignment
     :members:
 
-.. autoenum:: pygamelib.constants.Orientation
+.. autoenum:: pygamelib.constants.Algorithm
+    :members:
+
+.. autoenum:: pygamelib.constants.Direction
+    :members:
+
+.. autoenum:: pygamelib.constants.EngineConstant
+    :members:
+
+.. autoenum:: pygamelib.constants.EngineMode
     :members:
 
 .. autoenum:: pygamelib.constants.InputValidator
     :members:
 
-.. autoenum:: pygamelib.constants.Direction
+.. autoenum:: pygamelib.constants.Orientation
+    :members:
+
+.. autoenum:: pygamelib.constants.Permission
+    :members:
+
+.. autoenum:: pygamelib.constants.SizeConstraint
+    :members:
+
+.. autoenum:: pygamelib.constants.State
+    :members:
+
+.. autoenum:: pygamelib.constants.TextStyle
     :members:
 
 **The following constants are used in versions <= 1.3.0 and have been deprecated starting version 1.4.0.**

--- a/pygamelib/actuators.py
+++ b/pygamelib/actuators.py
@@ -15,10 +15,11 @@ __docformat__ = "restructuredtext"
 from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 from pygamelib import board_items
 from pygamelib import base
-from pygamelib import constants
+from pygamelib.constants import Direction, State, Algorithm
 import random
 import collections
 from queue import PriorityQueue
+
 if TYPE_CHECKING:
     from pygamelib import engine
 
@@ -45,7 +46,7 @@ class Actuator(base.PglBaseObject):
         """
         super().__init__()
         self.type = None
-        self.state = constants.RUNNING
+        self.state = State.RUNNING
         self.parent = parent
 
     def start(self):
@@ -58,7 +59,7 @@ class Actuator(base.PglBaseObject):
 
             mygame.start()
         """
-        self.state = constants.RUNNING
+        self.state = State.RUNNING
 
     def pause(self):
         """Set the actuator state to PAUSED.
@@ -67,7 +68,7 @@ class Actuator(base.PglBaseObject):
 
             mygame.pause()
         """
-        self.state = constants.PAUSED
+        self.state = State.PAUSED
 
     def stop(self):
         """Set the actuator state to STOPPED.
@@ -76,7 +77,7 @@ class Actuator(base.PglBaseObject):
 
             mygame.stop()
         """
-        self.state = constants.STOPPED
+        self.state = State.STOPPED
 
     def next_move(self) -> Union[base.Vector2D, int]:
         """
@@ -160,9 +161,11 @@ class RandomActuator(Actuator):
     :type parent: pygamelib.board_items.BoardItem
     """
 
-    def __init__(self,
-                 moveset: Optional[List[Union[base.Vector2D, int]]] = None,
-                 parent: Optional["board_items.BoardItem"] = None):
+    def __init__(
+        self,
+        moveset: Optional[List[Union[base.Vector2D, int]]] = None,
+        parent: Optional["board_items.BoardItem"] = None,
+    ):
         # Note: the length of the type hint suggests
         # that it was time for a MoveSet or a Move class
         if moveset is None:
@@ -222,7 +225,7 @@ class RandomActuator(Actuator):
 
             random_actuator.next_move()
         """
-        if self.state == constants.RUNNING and self.moveset:
+        if self.state == State.RUNNING and self.moveset:
             ppav = None
             if isinstance(self.parent, board_items.Movable):
                 ppav = self.parent.position_as_vector()
@@ -243,7 +246,7 @@ class RandomActuator(Actuator):
 
             # return random.choice(self.moveset)
         else:
-            return constants.NO_DIR
+            return Direction.NO_DIR
 
     def serialize(self) -> dict:
         """Return a dictionary with all the attributes of this object.
@@ -290,9 +293,11 @@ class PathActuator(Actuator):
     :type parent: pygamelib.board_items.BoardItem
     """
 
-    def __init__(self,
-                 path: Optional[List[int]] = None,
-                 parent: Optional["board_items.BoardItem"] = None):
+    def __init__(
+        self,
+        path: Optional[List[int]] = None,
+        parent: Optional["board_items.BoardItem"] = None,
+    ):
         if path is None:
             path = []  # pragma: no cover
         super().__init__(parent)
@@ -308,20 +313,20 @@ class PathActuator(Actuator):
         index equal the length of path, the index should return back to 0.
 
         :return: The next movement
-        :rtype: int | :py:const:`pygamelib.constants.NO_DIR`
+        :rtype: int | :py:const:`pygamelib.constants.Direction.NO_DIR`
 
         Example::
 
             path_actuator.next_move()
         """
-        if self.state == constants.RUNNING:
+        if self.state == State.RUNNING:
             move = self.path[self.index]
             self.index += 1
             if self.index == len(self.path):
                 self.index = 0
             return move
         else:
-            return constants.NO_DIR
+            return Direction.NO_DIR
 
     def set_path(self, path: List[int]):
         """Defines a new path
@@ -333,7 +338,7 @@ class PathActuator(Actuator):
 
         Example::
 
-            path_actuator.set_path([constants.UP,constants.DOWN,constants.LEFT,constants.RIGHT])
+            path_actuator.set_path([Direction.UP,Direction.DOWN,Direction.LEFT,Direction.RIGHT])
         """
         self.path = path
         self.index = 0
@@ -393,38 +398,38 @@ class PatrolActuator(PathActuator):
         should be reversed before the next call.
 
         :return: The next movement
-        :rtype: int | :py:const:`pygamelib.constants.NO_DIR`
+        :rtype: int | :py:const:`pygamelib.constants.Direction.NO_DIR`
 
         Example::
 
             patrol_actuator.next_move()
         """
-        if self.state == constants.RUNNING:
+        if self.state == State.RUNNING:
             move = self.path[self.index]
             self.index += 1
             if self.index == len(self.path):
                 self.index = 0
                 self.path.reverse()
                 for i in range(0, len(self.path)):
-                    if self.path[i] == constants.UP:
-                        self.path[i] = constants.DOWN
-                    elif self.path[i] == constants.DOWN:
-                        self.path[i] = constants.UP
-                    elif self.path[i] == constants.LEFT:
-                        self.path[i] = constants.RIGHT
-                    elif self.path[i] == constants.RIGHT:
-                        self.path[i] = constants.LEFT
-                    elif self.path[i] == constants.DLDOWN:
-                        self.path[i] = constants.DRUP
-                    elif self.path[i] == constants.DLUP:
-                        self.path[i] = constants.DRDOWN
-                    elif self.path[i] == constants.DRDOWN:
-                        self.path[i] = constants.DLUP
-                    elif self.path[i] == constants.DRUP:
-                        self.path[i] = constants.DLDOWN
+                    if self.path[i] == Direction.UP:
+                        self.path[i] = Direction.DOWN
+                    elif self.path[i] == Direction.DOWN:
+                        self.path[i] = Direction.UP
+                    elif self.path[i] == Direction.LEFT:
+                        self.path[i] = Direction.RIGHT
+                    elif self.path[i] == Direction.RIGHT:
+                        self.path[i] = Direction.LEFT
+                    elif self.path[i] == Direction.DLDOWN:
+                        self.path[i] = Direction.DRUP
+                    elif self.path[i] == Direction.DLUP:
+                        self.path[i] = Direction.DRDOWN
+                    elif self.path[i] == Direction.DRDOWN:
+                        self.path[i] = Direction.DLUP
+                    elif self.path[i] == Direction.DRUP:
+                        self.path[i] = Direction.DLDOWN
             return move
         else:
-            return constants.NO_DIR
+            return Direction.NO_DIR
 
     def serialize(self) -> dict:
         """Return a dictionary with all the attributes of this object.
@@ -469,11 +474,13 @@ class UnidirectionalActuator(Actuator):
     :type parent: pygamelib.board_items.BoardItem
     """
 
-    def __init__(self,
-                 direction: int = constants.RIGHT,
-                 parent: Optional["board_items.BoardItem"] = None):
+    def __init__(
+        self,
+        direction: int = Direction.RIGHT,
+        parent: Optional["board_items.BoardItem"] = None,
+    ):
         if direction is None:
-            direction = constants.RIGHT
+            direction = Direction.RIGHT
         super().__init__(parent)
         self.direction = direction
 
@@ -484,15 +491,15 @@ class UnidirectionalActuator(Actuator):
         otherwise it returns NO_DIR from the :py:mod:`~pygamelib.constants` module.
 
         :return: The next movement
-        :rtype: int | :py:const:`pygamelib.constants.NO_DIR`
+        :rtype: int | :py:const:`pygamelib.Direction.NO_DIR`
 
         Example::
 
             unidirectional_actuator.next_move()
         """
-        if self.state == constants.RUNNING:
+        if self.state == State.RUNNING:
             return self.direction
-        return constants.NO_DIR
+        return Direction.NO_DIR
 
     def serialize(self) -> dict:
         """Return a dictionary with all the attributes of this object.
@@ -561,7 +568,7 @@ class PathFinder(Behavioral):
         actuated_object: Optional["board_items.BoardItem"] = None,
         circle_waypoints=True,
         parent: Optional["board_items.BoardItem"] = None,
-        algorithm=constants.ALGO_BFS,
+        algorithm=Algorithm.BFS,
     ):
         effective_parent = parent
         if actuated_object is not None and parent is None:
@@ -578,13 +585,14 @@ class PathFinder(Behavioral):
         self._waypoint_index = 0
         self.circle_waypoints = circle_waypoints
         self.algorithm = algorithm
-        if type(self.algorithm) is not int or (
-            self.algorithm != constants.ALGO_BFS
-            and self.algorithm != constants.ALGO_ASTAR
-        ):
+        if (
+            type(self.algorithm) is not int and type(self.algorithm) is not Algorithm
+        ) or (self.algorithm != Algorithm.BFS and self.algorithm != Algorithm.ASTAR):
+            # TODO: it would be better to have a method that return a list of
+            #      implemented algorithm and to check if self.algorithm is in that list.
             raise base.PglInvalidTypeException(
                 "In Actuator.PathFinder.__init__(..,algorithm) algorithm must be"
-                "either ALGO_BFS or ALGO_ASTAR."
+                "either Algorithm.BFS or Algorithm.ASTAR."
             )
 
     def set_destination(self, row: int = 0, column: int = 0):
@@ -657,7 +665,7 @@ class PathFinder(Behavioral):
                 "destination is not defined",
                 "PathFinder.destination has to be defined.",
             )
-        if self.algorithm == constants.ALGO_BFS:
+        if self.algorithm == Algorithm.BFS:
             return self.__find_path_bfs()
 
         return self.__find_path_astar()
@@ -796,14 +804,14 @@ class PathFinder(Behavioral):
                 seeker.actuator.set_destination(mygame.player.pos[0],mygame.player.pos[1])
                 # next_move() will call find_path() for us.
                 next_move = seeker.actuator.next_move()
-                if next_move == constants.NO_DIR:
+                if next_move == Direction.NO_DIR:
                     seeker.actuator.set_destination(mygame.player.pos[0],mygame.player.pos[1])
                 else:
                     mygame.current_board().move(seeker,next_move,1)
         """
         # If one of destination coordinate is None, return NO_DIR
         if self.destination[0] is None or self.destination[1] is None:
-            return constants.NO_DIR
+            return Direction.NO_DIR
 
         # If path is empty and actuated_object is not at destination,
         # try to find a path to destination
@@ -831,12 +839,12 @@ class PathFinder(Behavioral):
                     self.find_path()
                 else:
                     # If there are no more waypoints, then we return NO_DIR
-                    return constants.NO_DIR
+                    return Direction.NO_DIR
             else:
-                return constants.NO_DIR
+                return Direction.NO_DIR
 
         if len(self._current_path) == 0:
-            return constants.NO_DIR
+            return Direction.NO_DIR
 
         # Get the next position from the path
         next_position = self._current_path.pop(0)
@@ -847,7 +855,7 @@ class PathFinder(Behavioral):
             and next_position[1] == self.actuated_object.pos[1]
         ):
             if len(self._current_path) == 0:
-                return constants.NO_DIR
+                return Direction.NO_DIR
             next_position = self._current_path.pop(0)
 
         # print(f'Next position is: {next_position} and object position is
@@ -866,27 +874,27 @@ class PathFinder(Behavioral):
         #   numerous in case the user use a step higher than 1 in Board.move().
         #   The actuated object could end up going into a wall or out of bound.
         if dr == -1 and dc == 0:
-            return constants.DOWN
+            return Direction.DOWN
         elif dr == 1 and dc == 0:
-            return constants.UP
+            return Direction.UP
         elif dr == 0 and dc == 1:
-            return constants.LEFT
+            return Direction.LEFT
         elif dr == 0 and dc == -1:
-            return constants.RIGHT
+            return Direction.RIGHT
         elif dr == -1 and dc == -1:
-            return constants.DRDOWN
+            return Direction.DRDOWN
         elif dr == 1 and dc == -1:
-            return constants.DRUP
+            return Direction.DRUP
         elif dr == -1 and dc == 1:
-            return constants.DLDOWN
+            return Direction.DLDOWN
         elif dr == 1 and dc == 1:
-            return constants.DLUP
+            return Direction.DLUP
         elif dr > 1 or dr < -1 or dc > 1 or dc < -1:
             # If we are here it means that something is blocking the movement
             self.find_path()
             return self.next_move()
         else:
-            return constants.NO_DIR
+            return Direction.NO_DIR
 
     def add_waypoint(self, row: int, column: int):
         """Add a waypoint to the list of waypoints.

--- a/pygamelib/base.py
+++ b/pygamelib/base.py
@@ -1,4 +1,4 @@
-from pygamelib import constants
+from pygamelib.constants import Direction
 from pygamelib.functions import pgl_isinstance
 import math
 from colorama import Fore, Back, Style, init
@@ -1245,7 +1245,7 @@ class Vector2D(object):
                 print('We are not moving... at all...')
         """
         return round(
-            math.sqrt(self.row**2 + self.column**2), self.rounding_precision
+            math.sqrt(self.row ** 2 + self.column ** 2), self.rounding_precision
         )
 
     def unit(self):
@@ -1267,37 +1267,37 @@ class Vector2D(object):
         )
 
     @classmethod
-    def from_direction(cls, direction, step):
+    def from_direction(cls, direction: Direction, step):
         """Build and return a Vector2D from a direction.
 
         Directions are from the constants module.
 
         :param direction: A direction from the constants module.
-        :type direction: int
+        :type direction: :py:enum:`~pygamelib.constants.Direction`
         :param step: The number of cell to cross in one movement.
         :type step: int
 
         Example::
 
-            v2d_up = Vector2D.from_direction(constants.UP, 1)
+            v2d_up = Vector2D.from_direction(Direction.UP, 1)
         """
-        if direction == constants.NO_DIR:
+        if direction == Direction.NO_DIR:
             return cls(0, 0)
-        elif direction == constants.UP:
+        elif direction == Direction.UP:
             return cls(-step, 0)
-        elif direction == constants.DOWN:
+        elif direction == Direction.DOWN:
             return cls(+step, 0)
-        elif direction == constants.LEFT:
+        elif direction == Direction.LEFT:
             return cls(0, -step)
-        elif direction == constants.RIGHT:
+        elif direction == Direction.RIGHT:
             return cls(0, +step)
-        elif direction == constants.DRUP:
+        elif direction == Direction.DRUP:
             return cls(-step, +step)
-        elif direction == constants.DRDOWN:
+        elif direction == Direction.DRDOWN:
             return cls(+step, +step)
-        elif direction == constants.DLUP:
+        elif direction == Direction.DLUP:
             return cls(-step, -step)
-        elif direction == constants.DLDOWN:
+        elif direction == Direction.DLDOWN:
             return cls(+step, -step)
 
     def serialize(self):

--- a/pygamelib/board_items.py
+++ b/pygamelib/board_items.py
@@ -33,7 +33,7 @@ __docformat__ = "restructuredtext"
 """
 from pygamelib import engine
 from pygamelib import base
-from pygamelib import constants
+from pygamelib.constants import Direction, Permission
 from pygamelib.gfx import core
 from pygamelib import actuators
 from pygamelib.functions import pgl_isinstance
@@ -949,7 +949,7 @@ class BoardComplexItem(BoardItem):
                     base.Text(
                         'Big boi detected!!!',
                         core.Color(255,0,0),
-                        style=constants.BOLD,
+                        style=TextStyle.BOLD,
                     ),
                     notifications.row,
                     notifications.column,
@@ -983,7 +983,7 @@ class BoardComplexItem(BoardItem):
                 # update_sprite() is called twice here.
                 item.sprite = s
                 item.update_sprite()
-                board.move(item, constants.RIGHT, 1)
+                board.move(item, Direction.RIGHT, 1)
                 time.sleep(0.2)
         """
         self._item_matrix = []
@@ -1292,7 +1292,7 @@ class Projectile(Movable):
     The Projectile constructor takes the following parameters:
 
     :param direction: A direction from the :ref:`constants-module` module
-    :type direction: int
+    :type direction: :py:enum:`~pygamelib.constants.Direction`
     :param range: The maximum range of the projectile in number of cells that can be
         crossed. When range is attained the hit_callback is called with a BoardItemVoid
         as a collision object.
@@ -1343,7 +1343,7 @@ class Projectile(Movable):
                                 # won't collide with other projectiles.
                                 collision_exclusions = [Projectile],
                             )
-        fireball.set_direction(constants.RIGHT)
+        fireball.set_direction(Direction.RIGHT)
         my_game.add_projectile(1, fireball,
                                my_game.player.pos[0], my_game.player.pos[1] + 1)
 
@@ -1353,7 +1353,7 @@ class Projectile(Movable):
     def __init__(
         self,
         name="projectile",
-        direction=constants.RIGHT,
+        direction=Direction.RIGHT,
         step=1,
         range=5,
         model="\U00002301",
@@ -1435,7 +1435,7 @@ class Projectile(Movable):
 
         Example::
 
-            fireball.add_directional_animation(constants.UP, constants.UP, animation)
+            fireball.add_directional_animation(Direction.UP, Direction.UP, animation)
         """
         if type(direction) is not int:
             raise base.PglInvalidTypeException(
@@ -1461,7 +1461,7 @@ class Projectile(Movable):
         Example::
 
             # No more animation for the UP direction
-            fireball.directional_animation(constants.UP)
+            fireball.directional_animation(Direction.UP)
         """
         if type(direction) is not int:
             raise base.PglInvalidTypeException(
@@ -1485,7 +1485,7 @@ class Projectile(Movable):
         Example::
 
             # No more animation for the UP direction
-            fireball.remove_directional_animation(constants.UP)
+            fireball.remove_directional_animation(Direction.UP)
         """
         if type(direction) is not int:
             raise base.PglInvalidTypeException(
@@ -1505,7 +1505,7 @@ class Projectile(Movable):
 
         Example::
 
-            fireball.add_directional_animation(constants.UP, upward_animation)
+            fireball.add_directional_animation(Direction.UP, upward_animation)
         """
         if type(direction) is not int:
             raise base.PglInvalidTypeException(
@@ -1528,7 +1528,7 @@ class Projectile(Movable):
 
         Example::
 
-            fireball.directional_model(constants.UP)
+            fireball.directional_model(Direction.UP)
         """
         if type(direction) is not int:
             raise base.PglInvalidTypeException(
@@ -1549,7 +1549,7 @@ class Projectile(Movable):
 
         Example::
 
-            fireball.directional_model(constants.UP)
+            fireball.directional_model(Direction.UP)
         """
         if type(direction) is not int:
             raise base.PglInvalidTypeException(
@@ -1571,7 +1571,7 @@ class Projectile(Movable):
 
         Example::
 
-            fireball.set_direction(constants.UP)
+            fireball.set_direction(Direction.UP)
         """
         if type(direction) is not int and not isinstance(direction, base.Vector2D):
             raise base.PglInvalidTypeException(
@@ -1727,7 +1727,7 @@ class Actionable(Immovable):
     :param perm: The permission that defines what types of items can actually
         activate the actionable. The permission has to be one of the
         permissions defined in :mod:`~pygamelib.constants`. By default it is set to
-        constants.PLAYER_AUTHORIZED.
+        Permission.PLAYER_AUTHORIZED.
     :type perm: :mod:`~pygamelib.constants`
 
     On top of these parameters Actionable accepts all parameters from
@@ -1751,7 +1751,7 @@ class Actionable(Immovable):
         self.action_parameters = []
         if action_parameters is not None:
             self.action_parameters = action_parameters
-        self.perm = constants.PLAYER_AUTHORIZED
+        self.perm = Permission.PLAYER_AUTHORIZED
         if perm is not None:
             self.perm = perm
 

--- a/pygamelib/constants.py
+++ b/pygamelib/constants.py
@@ -60,6 +60,75 @@ ALGO_ASTAR = 90000101
 BOLD = "\x1b[1m"
 UNDERLINE = "\x1b[4m"
 
+# New constants
+
+
+class EngineConstant(enum.IntEnum):
+    """
+    A couple of constants that controls the behavior of the engine itself.
+    """
+
+    NO_PLAYER = 90000001
+
+
+class EngineMode(enum.IntEnum):
+    """
+    Constants that controls the mode of the engine. So far, it's a choice between real
+    time and turn by turn, but in the future there could be additional modes.
+    """
+
+    MODE_REAL_TIME = 90000002
+    MODE_TURN_BY_TURN = 90000003
+
+
+class Permission(enum.IntEnum):
+    """
+    Permission constants to separate what objects are allowed to interact with others.
+    Mostly used to separate NPCs from Players.
+    """
+
+    PLAYER_AUTHORIZED = 20000001
+    NPC_AUTHORIZED = 20000010
+    ALL_CHARACTERS_AUTHORIZED = 20000011
+    ALL_PLAYABLE_AUTHORIZED = ALL_CHARACTERS_AUTHORIZED
+    ALL_MOVABLE_AUTHORIZED = 20000100
+    NONE_AUTHORIZED = 20000101
+
+
+class State(enum.IntEnum):
+    """
+    A set of constants that describe the internal state of something. For example the,
+    state of the :class:`~pygamelib.engine.Game` engine that are used to process or not
+    some events.
+    """
+
+    RUNNING = 40000001
+    PAUSED = 40000010
+    STOPPED = 40000011
+
+
+class Algorithm(enum.IntEnum):
+    """
+    A set of constants to identify the different algorithms used in the library (when a
+    choice is possible). For now, it's only the path finding algorithm.
+    """
+
+    BFS = 90000100
+    ASTAR = 90000101
+
+
+class TextStyle(str, enum.Enum):
+    """
+    TextStyling is used to format characters or text. It is mostly used by
+    :class:`~pygamelib.base.Text`.
+    """
+
+    # def __str__(self):
+    #     return str(self.value)
+
+    BOLD = "\x1b[1m"
+    UNDERLINE = "\x1b[4m"
+
 
 class SizeConstraint(enum.IntEnum):
     """

--- a/pygamelib/engine.py
+++ b/pygamelib/engine.py
@@ -21,7 +21,8 @@ The Board class is the base class for all levels.
    pygamelib.engine.Screen
 
 """
-from pygamelib import board_items, base, constants, actuators
+from pygamelib import board_items, base, actuators
+from pygamelib.constants import EngineConstant, EngineMode, State, Permission, Direction
 from pygamelib.assets import graphics
 from pygamelib.gfx import core, particles
 from pygamelib.functions import pgl_isinstance
@@ -1146,24 +1147,24 @@ class Board(base.PglBaseObject):
                             (
                                 isinstance(item, board_items.Player)
                                 and (
-                                    (dest_item.perm == constants.PLAYER_AUTHORIZED)
+                                    (dest_item.perm == Permission.PLAYER_AUTHORIZED)
                                     or (
                                         dest_item.perm
-                                        == constants.ALL_CHARACTERS_AUTHORIZED
+                                        == Permission.ALL_CHARACTERS_AUTHORIZED
                                     )
                                 )
                             )
                             or (
                                 isinstance(item, board_items.NPC)
                                 and (
-                                    (dest_item.perm == constants.NPC_AUTHORIZED)
+                                    (dest_item.perm == Permission.NPC_AUTHORIZED)
                                     or (
                                         dest_item.perm
-                                        == constants.ALL_CHARACTERS_AUTHORIZED
+                                        == Permission.ALL_CHARACTERS_AUTHORIZED
                                     )
                                 )
                             )
-                            or (dest_item.perm == constants.ALL_MOVABLE_AUTHORIZED)
+                            or (dest_item.perm == Permission.ALL_MOVABLE_AUTHORIZED)
                         ):
                             dest_item.activate()
                     # Now taking care of pickable objects
@@ -1201,7 +1202,8 @@ class Board(base.PglBaseObject):
         :param item: an item to move (it has to be a subclass of Movable)
         :type item: pygamelib.board_items.Movable
         :param direction: a direction from :ref:`constants-module`
-        :type direction: pygamelib.constants or :class:`~pygamelib.base.Vector2D`
+        :type direction: :py:enum:`~pygamelib.constants.Direction` or
+           :class:`~pygamelib.base.Vector2D`
         :param step: the number of steps to move the item.
         :type step: int
 
@@ -1213,7 +1215,7 @@ class Board(base.PglBaseObject):
 
         Example::
 
-            board.move(player,constants.UP,1)
+            board.move(player,Direction.UP,1)
 
         .. Important:: if the move is successful, an empty BoardItemVoid
             (see :class:`pygamelib.boards_item.BoardItemVoid`) will be put at the
@@ -1230,7 +1232,7 @@ class Board(base.PglBaseObject):
         if (
             self.parent is not None
             and isinstance(self.parent, Game)
-            and self.parent.mode == constants.MODE_RT
+            and self.parent.mode == EngineMode.MODE_REAL_TIME
             and isinstance(item, board_items.Movable)
             and item.can_move()
             and item.dtmove < item.movement_speed
@@ -1266,7 +1268,7 @@ class Board(base.PglBaseObject):
         #         "Board.move(item, direction, step): direction must be a Vector2D or"
         #         " a constant direction."
         #     )
-        if type(direction) is int:
+        if type(direction) is int or type(direction) is Direction:
             if type(step) is not int:
                 raise base.PglInvalidTypeException(
                     "Board.move(item, direction, step): step must be an int."
@@ -1319,18 +1321,18 @@ class Board(base.PglBaseObject):
                     (
                         isinstance(item, board_items.Player)
                         and (
-                            (dest_item.perm == constants.PLAYER_AUTHORIZED)
-                            or (dest_item.perm == constants.ALL_CHARACTERS_AUTHORIZED)
+                            (dest_item.perm == Permission.PLAYER_AUTHORIZED)
+                            or (dest_item.perm == Permission.ALL_CHARACTERS_AUTHORIZED)
                         )
                     )
                     or (
                         isinstance(item, board_items.NPC)
                         and (
-                            (dest_item.perm == constants.NPC_AUTHORIZED)
-                            or (dest_item.perm == constants.ALL_CHARACTERS_AUTHORIZED)
+                            (dest_item.perm == Permission.NPC_AUTHORIZED)
+                            or (dest_item.perm == Permission.ALL_CHARACTERS_AUTHORIZED)
                         )
                     )
-                    or (dest_item.perm == constants.ALL_MOVABLE_AUTHORIZED)
+                    or (dest_item.perm == Permission.ALL_MOVABLE_AUTHORIZED)
                 ):
                     dest_item.activate()
             # Now we check if the destination contains a pickable item.
@@ -1760,14 +1762,14 @@ class Game(base.PglBaseObject):
 
     def __init__(
         self,
-        name="Game",
-        player=None,
+        name: str = "Game",
+        player: "board_items.Player" = None,
         boards={},
         current_level=None,
         enable_partial_display=False,
         partial_display_viewport=None,
         partial_display_focus=None,
-        mode=constants.MODE_TBT,
+        mode=EngineMode.MODE_TURN_BY_TURN,
         user_update=None,
         input_lag=0.01,
         user_update_paused=None,
@@ -1792,15 +1794,15 @@ class Game(base.PglBaseObject):
            view when the board is displayed.
         :type partial_display_focus: :class:`~pygamelib.board_items.BoardItem`
         :param mode: The mode parameter configures the way the run() method is going to
-           behave. The default value is constants.MODE_TBT. TBT is short for "Turn By
-           Turn". In that mode, the Game object wait for an user input before looping.
+           behave. The default value is EngineMode.MODE_TURN_BY_TURN. In that mode,
+           the Game object wait for an user input before looping.
            Exactly like when you wait for user input with get_key(). The other possible
-           value is constants.MODE_RT. RT stands for "Real Time". In that mode, the Game
-           object waits for a minimal amount of time (0.01 i.e 100 FPS, configurable
-           through the input_lag parameter) in order to get the input from the user and
-           call the update function right away. This parameter is *only* useful if you
-           use Game.run().
-        :type mode: int
+           value is EngineMode.MODE_TURN_BY_TURN. RT stands for "Real Time". In that
+           mode, the Game object waits for a minimal amount of time (0.01 i.e 100 FPS,
+           configurable through the input_lag parameter) in order to get the input from
+           the user and call the update function right away. This parameter is *only*
+           useful if you use Game.run().
+        :type mode: :py:enum:`~pygamelib.constants.EngineMode`
         :param user_update: A reference to the main program update function. The update
            function is called for each new frame. It is called with 3 parameters: the
            game object, the user input (can be None) and the elapsed time since last
@@ -1822,7 +1824,7 @@ class Game(base.PglBaseObject):
         self._boards = boards
         self.current_level = current_level
         self.player = player
-        self.__state = constants.RUNNING
+        self.__state = State.RUNNING
         self.enable_partial_display = enable_partial_display
         self.partial_display_viewport = partial_display_viewport
         self.partial_display_focus = partial_display_focus
@@ -1842,7 +1844,7 @@ class Game(base.PglBaseObject):
         # self.enable_physic = enable_physic
         # # If physic is enabled we turn the mode to realtime (we need time integration)
         # if self.enable_physic:
-        #     self.mode = constants.MODE_RT
+        #     self.mode = EngineMode.MODE_REAL_TIME
         #     self.gravity = base.Vector2D(9.81, 0)
         # else:
         #     self.gravity = None
@@ -1851,7 +1853,7 @@ class Game(base.PglBaseObject):
         # In the case where user_update is defined, we cannot start the game on our own.
         # We need the user to start it first.
         if self.user_update is not None:
-            self.__state = constants.PAUSED
+            self.__state = State.PAUSED
         if user_update_paused is not None:
             self.user_update_paused = user_update_paused
         self.previous_time = time.time()
@@ -1862,9 +1864,9 @@ class Game(base.PglBaseObject):
         """Get/set the state of the game.
 
         :param value: The new state of the game (from the constants module).
-        :type value: int
+        :type value: :py:enum:`~pygamelib.constants.State`
         :return: The state of the game.
-        :rtype: int
+        :rtype: :py:enum:`~pygamelib.constants.State`
 
         The observers are notified of a change of state with the
         :boldblue:`pygamelib.engine.Game.state` event. The new state is passed as the
@@ -1875,10 +1877,10 @@ class Game(base.PglBaseObject):
     @state.setter
     def state(self, value):
         self.__state = value
-        if value == constants.PAUSED:
+        if value == State.PAUSED:
             if self.user_update_paused is None:
                 self.user_update_paused = self._fake_update_paused
-        elif value == constants.RUNNING:
+        elif value == State.RUNNING:
             self._set_run_function()
         self.notify(self, "pygamelib.engine.Game.state", value)
 
@@ -1959,16 +1961,16 @@ class Game(base.PglBaseObject):
                 "Game.run(): user_update must be callable."
             )
         # Auto start if game hasn't be started before
-        if self.state == constants.PAUSED:
+        if self.state == State.PAUSED:
             self.start()
         # Update the inkey timeout based on mode
         # This cannot be automatically tested as it means the main loop requires an user
         # input.
-        if self.mode == constants.MODE_TBT:  # pragma: no cover
+        if self.mode == EngineMode.MODE_TURN_BY_TURN:  # pragma: no cover
             self.input_lag = None
         self.previous_time = time.perf_counter()
         if self.player is None:
-            self.player = constants.NO_PLAYER
+            self.player = EngineConstant.NO_PLAYER
         # Now we check that we do have a current board. If not, it means that the user
         # wants to use the game object without any board.
         self._set_run_function()
@@ -1982,13 +1984,13 @@ class Game(base.PglBaseObject):
     # loop. Each crumble of performance is worth a little bit of extra code.
     def _run_with_board(self):
         # This runs until the game stops
-        while self.state != constants.STOPPED:
+        while self.state != State.STOPPED:
             # But we only update if the game is not paused
             in_key = self.terminal.inkey(timeout=self.input_lag)
             elapsed = time.perf_counter() - self.previous_time
             self.previous_time = time.perf_counter()
-            if self.state == constants.RUNNING:
-                if self.player != constants.NO_PLAYER:
+            if self.state == State.RUNNING:
+                if self.player != EngineConstant.NO_PLAYER:
                     self.player.dtmove += elapsed
                 # print(self.terminal.home, end="")
                 self.user_update(self, in_key, elapsed)
@@ -1996,7 +1998,7 @@ class Game(base.PglBaseObject):
                 self.actuate_npcs(self.current_level, elapsed)
                 self.actuate_projectiles(self.current_level, elapsed)
                 self.animate_items(self.current_level, elapsed)
-            elif self.state == constants.PAUSED:
+            elif self.state == State.PAUSED:
                 print(self.terminal.home, end="")
                 self.user_update_paused(self, in_key, elapsed)
                 print(self.terminal.clear_eos, end="")
@@ -2009,16 +2011,16 @@ class Game(base.PglBaseObject):
 
     def _run_without_board(self):
         # This runs until the game stops
-        while self.state != constants.STOPPED:
+        while self.state != State.STOPPED:
             in_key = self.terminal.inkey(timeout=self.input_lag)
             elapsed = time.perf_counter() - self.previous_time
             self.previous_time = time.perf_counter()
             # But we only update if the game is not paused
-            if self.state == constants.RUNNING:
+            if self.state == State.RUNNING:
                 print(self.terminal.home, end="")
                 self.user_update(self, in_key, elapsed)
                 print(self.terminal.clear_eos, end="")
-            elif self.state == constants.PAUSED:
+            elif self.state == State.PAUSED:
                 print(self.terminal.home, end="")
                 self.user_update_paused(self, in_key, elapsed)
                 print(self.terminal.clear_eos, end="")
@@ -2383,11 +2385,11 @@ class Game(base.PglBaseObject):
                     "undefined_player",
                     "Game.player is undefined. We cannot change level without a player."
                     " Please set player in your Game object: mygame.player = Player()"
-                    " or set mygame.player = constants.NO_PLAYER",
+                    " or set mygame.player = EngineConstant.NO_PLAYER",
                 )
             if level_number in self._boards.keys():
                 # If player is not None and not NO_PLAYER let's work
-                if self.player != constants.NO_PLAYER:
+                if self.player != EngineConstant.NO_PLAYER:
                     # If it's not already the case, taking ownership of player
                     if self.player.parent != self:
                         self.player.parent = self
@@ -2517,10 +2519,10 @@ class Game(base.PglBaseObject):
                         if npc.actuator is None:
                             npc.actuator = actuators.RandomActuator(
                                 moveset=[
-                                    constants.UP,
-                                    constants.DOWN,
-                                    constants.LEFT,
-                                    constants.RIGHT,
+                                    Direction.UP,
+                                    Direction.DOWN,
+                                    Direction.LEFT,
+                                    Direction.RIGHT,
                                 ],
                                 parent=npc,
                             )
@@ -2581,16 +2583,16 @@ class Game(base.PglBaseObject):
         .. note:: Since version 1.2.0 and the appearance of the realtime mode, we have
            to account for movement speed. This method does it.
         """
-        if self.state == constants.RUNNING:
+        if self.state == State.RUNNING:
             if type(level_number) is int:
                 if level_number in self._boards.keys():
                     self.screen.trigger_rendering()
                     for npc in self._boards[level_number]["npcs"]:
-                        if npc.actuator.state == constants.RUNNING:
+                        if npc.actuator.state == State.RUNNING:
                             # Account for movement speed
                             npc.dtmove += elapsed_time
                             if (
-                                self.mode == constants.MODE_RT
+                                self.mode == EngineMode.MODE_REAL_TIME
                                 and npc.dtmove < npc.movement_speed
                             ):
                                 continue
@@ -2687,7 +2689,7 @@ class Game(base.PglBaseObject):
                                 return
                         if projectile.actuator is None:
                             projectile.actuator = actuators.RandomActuator(
-                                moveset=[constants.RIGHT]
+                                moveset=[Direction.RIGHT]
                             )
                         if projectile.step is None:
                             projectile.step = 1
@@ -2765,7 +2767,7 @@ class Game(base.PglBaseObject):
             :meth:`pygamelib.board_items.Projectile.hit` method for more information on
             the projectile hit mechanic.
         """
-        if self.state == constants.RUNNING:
+        if self.state == State.RUNNING:
             if type(level_number) is int:
                 if level_number in self._boards.keys():
                     self.screen.trigger_rendering()
@@ -2786,11 +2788,11 @@ class Game(base.PglBaseObject):
                     pp = base.Vector2D()
 
                     for proj in self._boards[level_number]["projectiles"]:
-                        if proj.actuator.state == constants.RUNNING:
+                        if proj.actuator.state == State.RUNNING:
                             # Account for movement speed
                             proj.dtmove += elapsed_time
                             if (
-                                self.mode == constants.MODE_RT
+                                self.mode == EngineMode.MODE_REAL_TIME
                                 and proj.dtmove < proj.movement_speed
                             ):
                                 continue
@@ -2870,7 +2872,7 @@ class Game(base.PglBaseObject):
                                 #     self._boards[level_number][
                                 #         "board"
                                 #     ]._movables.discard(proj)
-                        elif proj.actuator.state == constants.STOPPED:
+                        elif proj.actuator.state == State.STOPPED:
                             self._boards[level_number]["projectiles"].remove(proj)
                             board.clear_cell(proj.pos[0], proj.pos[1], proj.pos[2])
                             # There is a possibility when a lot of projectiles are on
@@ -2928,7 +2930,7 @@ class Game(base.PglBaseObject):
             mygame.animate_items(1)
 
         """
-        if self.state == constants.RUNNING:
+        if self.state == State.RUNNING:
             if type(level_number) is int:
                 if level_number in self._boards.keys():
                     for item in (
@@ -2938,7 +2940,7 @@ class Game(base.PglBaseObject):
                         if item.animation is not None:
                             item.animation.dtanimate += elapsed_time
                             if (
-                                self.mode == constants.MODE_RT
+                                self.mode == EngineMode.MODE_REAL_TIME
                                 and item.animation.dtanimate
                                 < item.animation.display_time
                             ):
@@ -2981,7 +2983,7 @@ class Game(base.PglBaseObject):
             template of what to display.
 
         """
-        if self.player is None or self.player == constants.NO_PLAYER:
+        if self.player is None or self.player == EngineConstant.NO_PLAYER:
             return ""
         info = ""
         info += f" {self.player.name}"
@@ -2996,12 +2998,12 @@ class Game(base.PglBaseObject):
 
         Example::
 
-            mygame.move_player(constants.RIGHT,1)
+            mygame.move_player(Direction.RIGHT,1)
         """
         if (
-            self.state == constants.RUNNING
+            self.state == State.RUNNING
             and self.player is not None
-            and self.player != constants.NO_PLAYER
+            and self.player != EngineConstant.NO_PLAYER
         ):
             self._boards[self.current_level]["board"].move(self.player, direction, step)
             if isinstance(self.screen, Screen):
@@ -3017,8 +3019,8 @@ class Game(base.PglBaseObject):
         The partial display will be centered on the player (Game.player).
         Otherwise it will just call Game.current_board().display().
 
-        If the player is not set or is set to constants.NO_PLAYER partial display won't
-        activate automatically.
+        If the player is not set or is set to EngineConstant.NO_PLAYER partial display
+        won't activate automatically.
 
         Example::
 
@@ -3037,7 +3039,7 @@ class Game(base.PglBaseObject):
             and self.partial_display_viewport is not None
             and type(self.partial_display_viewport) is list
             and self.player is not None
-            and self.player != constants.NO_PLAYER
+            and self.player != EngineConstant.NO_PLAYER
         ):
             # display_around(self, object, p_row, p_col)
             self.current_board().display_around(
@@ -3257,7 +3259,7 @@ class Game(base.PglBaseObject):
 
             mygame.start()
         """
-        self.state = constants.RUNNING
+        self.state = State.RUNNING
         self.previous_time = time.perf_counter()
 
     def pause(self):
@@ -3267,7 +3269,7 @@ class Game(base.PglBaseObject):
 
             mygame.pause()
         """
-        self.state = constants.PAUSED
+        self.state = State.PAUSED
 
     def stop(self):
 
@@ -3277,28 +3279,28 @@ class Game(base.PglBaseObject):
 
             mygame.stop()
         """
-        self.state = constants.STOPPED
+        self.state = State.STOPPED
 
     @staticmethod
     def _string_to_constant(s):
         if type(s) is int:
             return s
         elif s == "UP":
-            return constants.UP
+            return Direction.UP
         elif s == "DOWN":
-            return constants.DOWN
+            return Direction.DOWN
         elif s == "RIGHT":
-            return constants.RIGHT
+            return Direction.RIGHT
         elif s == "LEFT":
-            return constants.LEFT
+            return Direction.LEFT
         elif s == "DRUP":
-            return constants.DRUP
+            return Direction.DRUP
         elif s == "DRDOWN":
-            return constants.DRDOWN
+            return Direction.DRDOWN
         elif s == "DLDOWN":
-            return constants.DLDOWN
+            return Direction.DLDOWN
         elif s == "DLUP":
-            return constants.DLUP
+            return Direction.DLUP
 
     @staticmethod
     def _ref2obj(ref):

--- a/pygamelib/gfx/core.py
+++ b/pygamelib/gfx/core.py
@@ -13,7 +13,7 @@ __docformat__ = "restructuredtext"
    pygamelib.gfx.core.Font
 """
 from pygamelib import base
-from pygamelib import constants
+from pygamelib.constants import State
 from pygamelib.assets import graphics
 from pygamelib.functions import pgl_isinstance
 import random
@@ -1948,7 +1948,7 @@ class Animation(object):
         initial_index=None,
         parent=None,
     ):
-        self.state = constants.RUNNING
+        self.state = State.RUNNING
         self.display_time = display_time
         self.auto_replay = auto_replay
         self.parent = None
@@ -2052,16 +2052,16 @@ class Animation(object):
             )
 
     def start(self):
-        """Set the animation state to constants.RUNNING.
+        """Set the animation state to State.RUNNING.
 
-        If the animation state is not constants.RUNNING, animation's next_frame()
+        If the animation state is not State.RUNNING, animation's next_frame()
         function return the last frame returned.
 
         Example::
 
             item.animation.start()
         """
-        self.state = constants.RUNNING
+        self.state = State.RUNNING
 
     def pause(self):
         """Set the animation state to PAUSED.
@@ -2070,7 +2070,7 @@ class Animation(object):
 
             item.animation.pause()
         """
-        self.state = constants.PAUSED
+        self.state = State.PAUSED
 
     def stop(self):
         """Set the animation state to STOPPED.
@@ -2079,7 +2079,7 @@ class Animation(object):
 
             item.animation.stop()
         """
-        self.state = constants.STOPPED
+        self.state = State.STOPPED
 
     def add_frame(self, frame):
         """Add a frame to the animation.
@@ -2189,7 +2189,7 @@ class Animation(object):
         animation.
 
         That method takes care of automatically resetting the animation if the
-        last frame is reached if the state is constants.RUNNING.
+        last frame is reached if the state is State.RUNNING.
 
         If the the state is PAUSED it still update the parent.model
         and returning the current frame. It does NOT actually go to next frame.
@@ -2211,9 +2211,9 @@ class Animation(object):
             raise base.PglInvalidTypeException(
                 "The parent needs to be a sub class of BoardItem."
             )
-        if self.state == constants.STOPPED:
+        if self.state == State.STOPPED:
             return
-        elif self.state == constants.RUNNING:
+        elif self.state == State.RUNNING:
             self._frame_index += 1
             if self._frame_index >= len(self.frames):
                 if self.auto_replay:
@@ -2254,7 +2254,7 @@ class Animation(object):
 
             item.animation.play_all()
         """
-        if self.state == constants.PAUSED or self.state == constants.STOPPED:
+        if self.state == State.PAUSED or self.state == State.STOPPED:
             return False
         if self.refresh_screen is None or not callable(self.refresh_screen):
             raise base.PglInvalidTypeException(

--- a/pygamelib/gfx/ui.py
+++ b/pygamelib/gfx/ui.py
@@ -274,7 +274,7 @@ class Box(object):
         config: UiConfig = None,
         fill: bool = False,
         filling_sprixel: core.Sprixel = None,
-        title_alignment: int = constants.ALIGN_CENTER,
+        title_alignment: constants.Alignment = constants.Alignment.CENTER,
     ):
         """
         The box constructor takes the following parameters.
@@ -948,9 +948,8 @@ class MessageDialog(Dialog):
     anything that can be rendered on screen (i.e: posess a render_to_buffer(self, buffer
     , row, column, buffer_height, buffer_width) method).
 
-    Each line can be aligned separately using :py:const:`constants.ALIGN_RIGHT`,
-    :py:const:`constants.ALIGN_LEFT` or :py:const:`constants.ALIGN_CENTER`. Please see
-    :meth:`add_line`.
+    Each line can be aligned separately using one of the
+    :py:enum:`~pygamelib.constants.Alignment` constants. Please see :meth:`add_line`.
 
     It also implements the `show()` virtual method of :class:`Dialog`.
     This method is blocking and has its own event loop. It does not return anything.
@@ -976,7 +975,7 @@ class MessageDialog(Dialog):
         width: int = 20,
         height: int = None,
         adaptive_height: bool = True,
-        alignment: int = None,
+        alignment: constants.Alignment = None,
         title: str = None,
         config: UiConfig = None,
     ) -> None:
@@ -995,9 +994,9 @@ class MessageDialog(Dialog):
            to match the content size.
         :type adaptive_height: bool
         :param alignment: The alignment to apply to the data parameter. Please use the
-           constants.ALIGN_* constants. The default value is
-           :py:const:`constants.ALIGN_LEFT`
-        :type alignment: int
+           :py:enum:`~pygamelib.constants.Alignment` constants. The default value is
+           :py:const:`pygamelib.constants.Alignment.LEFT`
+        :type alignment: :py:enum:`~pygamelib.constants.Alignment`
         :param title: The short title of the dialog. Only used when the dialog is not
            borderless.
         :type title: str
@@ -1008,16 +1007,16 @@ class MessageDialog(Dialog):
 
             msg = MessageDialog(
                 [
-                    base.Text('HELP', core.Color(0,125,255), style=constants.BOLD),
-                    base.Text('----', core.Color(0,125,255), style=constants.BOLD),
+                    base.Text('HELP', core.Color(0,125,255), style=TextStyle.BOLD),
+                    base.Text('----', core.Color(0,125,255), style=TextStyle.BOLD),
                     '',
                 ],
                 20,
                 5,
                 True,
-                constants.ALIGN_CENTER,
+                Alignment.CENTER,
             )
-            msg.add_line('This is aligned on the right', constants.ALGIN_RIGHT)
+            msg.add_line('This is aligned on the right', Alignment.RIGHT)
             msg.add_line('This is aligned on the left')
             screen.place(msg, 10, 10)
             msg.show()
@@ -1025,7 +1024,7 @@ class MessageDialog(Dialog):
         """
         super().__init__(config=config)
         if alignment is None:
-            alignment = constants.ALIGN_LEFT
+            alignment = constants.Alignment.LEFT
         if adaptive_height is False and height is None:
             adaptive_height = True
         self.__cache = {"data": []}
@@ -1108,7 +1107,9 @@ class MessageDialog(Dialog):
             )
         self.config.game.screen.trigger_rendering()
 
-    def add_line(self, data, alignment=constants.ALIGN_LEFT) -> None:
+    def add_line(
+        self, data, alignment: constants.Alignment = constants.Alignment.LEFT
+    ) -> None:
         """
         Add a line to the message dialog.
 
@@ -1129,8 +1130,7 @@ class MessageDialog(Dialog):
         :param data: The data to add to the message dialog.
         :type data: various
         :param alignment: The alignment of the line to add.
-        :type alignment: :py:const:`constants.ALIGN_RIGHT` |
-           :py:const:`constants.ALIGN_LEFT` | :py:const:`constants.ALIGN_CENTER`
+        :type alignment: :py:enum:`~pygamelib.constants.Alignment`
 
         Example::
 
@@ -1139,9 +1139,10 @@ class MessageDialog(Dialog):
                     'This is centered and very red',
                     core.Color(255,0,0),
                 ),
-                constants.ALGIN_CENTER,
+                constants.Alignment.CENTER,
             )
         """
+        # TODO: Test that alignment is a constants.Alignment
         if (
             isinstance(data, core.Sprixel)
             or type(data) is str
@@ -1187,12 +1188,12 @@ class MessageDialog(Dialog):
             padding = 0
             alignment = self.__data[idx][1]
             data = self.__data[idx][0]
-            if alignment == constants.ALIGN_RIGHT:
+            if alignment == constants.Alignment.RIGHT:
                 if type(data) is str:
                     padding = self.__width - len(data) - 2
                 elif hasattr(data, "length"):
                     padding = self.__width - data.length - 2
-            elif alignment == constants.ALIGN_CENTER:
+            elif alignment == constants.Alignment.CENTER:
                 if type(data) is str:
                     padding = int((self.__width - len(data) - 2) / 2)
                 elif hasattr(data, "length"):
@@ -1277,7 +1278,7 @@ class LineInputDialog(Dialog):
         title=None,
         label="Input a value:",
         default="",
-        filter=constants.PRINTABLE_FILTER,
+        filter=constants.InputValidator.PRINTABLE_FILTER,
         config=None,
     ) -> None:
         """
@@ -1290,8 +1291,7 @@ class LineInputDialog(Dialog):
         :type default: str
         :param filter: Sets the type of accepted input. It comes from the
            :mod:`constants` module.
-        :type filter: :py:const:`constants.PRINTABLE_FILTER` |
-           :py:const:`constants.INTEGER_FILTER`
+        :type filter: :py:enum:`~pygamelib.constants.InputValidator`
         :param config: The configuration object.
         :type config: :class:`UiConfig`
 
@@ -1435,8 +1435,12 @@ class LineInputDialog(Dialog):
                     screen.trigger_rendering()
                     screen.update()
                 elif (
-                    self.__filter == constants.PRINTABLE_FILTER and inkey.isprintable()
-                ) or (self.__filter == constants.INTEGER_FILTER and inkey.isdigit()):
+                    self.__filter == constants.InputValidator.PRINTABLE_FILTER
+                    and inkey.isprintable()
+                ) or (
+                    self.__filter == constants.InputValidator.INTEGER_FILTER
+                    and inkey.isdigit()
+                ):
                     self.user_input += str(inkey)
                     screen.trigger_rendering()
                     screen.update()
@@ -1475,7 +1479,7 @@ class MultiLineInputDialog(Dialog):
             {
                 "label": "Input a value:",
                 "default": "",
-                "filter": constants.PRINTABLE_FILTER,
+                "filter": constants.InputValidator.PRINTABLE_FILTER,
             }
         ],
         title: str = None,
@@ -1498,8 +1502,7 @@ class MultiLineInputDialog(Dialog):
          * "default": A string that is going to pre-fill the input field.
          * "filter": A filter to configure the acceptable inputs.
 
-        The filters are coming from the constants module and can be either
-        :py:const:`constants.INTEGER_FILTER` or :py:const:`constants.PRINTABLE_FILTER`.
+        The filters needs to be a :py:enum:`~pygamelib.constants.InputValidator`.
 
         Example::
 
@@ -1507,17 +1510,17 @@ class MultiLineInputDialog(Dialog):
                 {
                     "label": "Enter the height of the new sprite:",
                     "default": "",
-                    "filter": constants.INTEGER_FILTER,
+                    "filter": constants.InputValidator.INTEGER_FILTER,
                 },
                 {
                     "label": "Enter the width of the new sprite:",
                     "default": "",
-                    "filter": constants.INTEGER_FILTER,
+                    "filter": constants.InputValidator.INTEGER_FILTER,
                 },
                 {
                     "label": "Enter the name of the new sprite:",
                     "default": f"Sprite {len(sprite_list)}",
-                    "filter": constants.PRINTABLE_FILTER,
+                    "filter": constants.InputValidator.PRINTABLE_FILTER,
                 },
             ]
             multi_input = MultiLineInput(fields, conf)
@@ -1682,7 +1685,7 @@ class MultiLineInputDialog(Dialog):
                 {
                     "label": "Input a value:",
                     "default": "",
-                    "filter": constants.PRINTABLE_FILTER,
+                    "filter": constants.InputValidator.PRINTABLE_FILTER,
                 }
             ]
 
@@ -1694,7 +1697,7 @@ class MultiLineInputDialog(Dialog):
                 {
                     "label": "Input a value:",
                     "default": "",
-                    "filter": constants.PRINTABLE_FILTER,
+                    "filter": constants.InputValidator.PRINTABLE_FILTER,
                     "user_input": "some input",
                 }
             ]
@@ -1731,11 +1734,11 @@ class MultiLineInputDialog(Dialog):
                     screen.update()
                 elif (
                     self.__fields[self.__current_field]["filter"]
-                    == constants.PRINTABLE_FILTER
+                    == constants.InputValidator.PRINTABLE_FILTER
                     and inkey.isprintable()
                 ) or (
                     self.__fields[self.__current_field]["filter"]
-                    == constants.INTEGER_FILTER
+                    == constants.InputValidator.INTEGER_FILTER
                     and inkey.isdigit()
                 ):
                     self.__fields[self.__current_field]["user_input"] += str(inkey)
@@ -2064,7 +2067,7 @@ class FileDialog(Dialog):
             txt = base.Text(i.name)
             if idx == self.__browsing_position:
                 txt.fg_color = core.Color(0, 255, 0)
-                txt.style = constants.BOLD
+                txt.style = constants.TextStyle.BOLD
                 self.__current_selection = i
                 if i.is_file():
                     # Can't be tested since the widget do not offer the ability to
@@ -2715,10 +2718,8 @@ class ColorPicker(object):
         """
         The constructor is really simple and takes only 2 arguments.
 
-        :param orientation: One of the 2 orientation constants
-           :py:const:`pygamelib.constants.ORIENTATION_HORIZONTAL` or
-           :py:const:`pygamelib.constants.ORIENTATION_VERTICAL`
-        :type orientation: int
+        :param orientation: One of the orientation constants.
+        :type orientation: :py:enum:`~pygamelib.constants.Orientation`
         :param config: The configuration object.
         :type config: :class:`UiConfig`
 
@@ -2728,12 +2729,12 @@ class ColorPicker(object):
 
         Example::
 
-            color_picker = ColorPicker(constants.ORIENTATION_HORIZONTAL, conf)
+            color_picker = ColorPicker(constants.Orientation.HORIZONTAL, conf)
             screen.place(color_picker, 10, 10)
             screen.update()
         """
         super().__init__()
-        self.__orientation = constants.ORIENTATION_HORIZONTAL
+        self.__orientation = constants.Orientation.HORIZONTAL
         if orientation is not None and type(orientation) is int:
             self.__orientation = orientation
         self._config = None
@@ -2947,7 +2948,7 @@ class ColorPickerDialog(Dialog):
         """
         super().__init__(config=config)
         self.__color_picker = ColorPicker(
-            orientation=constants.ORIENTATION_HORIZONTAL, config=config
+            orientation=constants.Orientation.HORIZONTAL, config=config
         )
         self.__title = title
         if self.__title is None:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,6 @@
 import pygamelib.base as base
 import pygamelib.gfx.core as core
+from pygamelib.constants import Direction
 import unittest
 
 
@@ -93,23 +94,23 @@ class TestBase(unittest.TestCase):
         v.column = 1.0
 
     def test_v2d_create(self):
-        v = base.Vector2D.from_direction(base.constants.NO_DIR, 1)
+        v = base.Vector2D.from_direction(Direction.NO_DIR, 1)
         self.assertEqual(v, base.Vector2D(0, 0))
-        v = base.Vector2D.from_direction(base.constants.UP, 1)
+        v = base.Vector2D.from_direction(Direction.UP, 1)
         self.assertEqual(v, base.Vector2D(-1, 0))
-        v = base.Vector2D.from_direction(base.constants.DOWN, 1)
+        v = base.Vector2D.from_direction(Direction.DOWN, 1)
         self.assertEqual(v, base.Vector2D(1, 0))
-        v = base.Vector2D.from_direction(base.constants.LEFT, 1)
+        v = base.Vector2D.from_direction(Direction.LEFT, 1)
         self.assertEqual(v, base.Vector2D(0, -1))
-        v = base.Vector2D.from_direction(base.constants.RIGHT, 1)
+        v = base.Vector2D.from_direction(Direction.RIGHT, 1)
         self.assertEqual(v, base.Vector2D(0, 1))
-        v = base.Vector2D.from_direction(base.constants.DRUP, 1)
+        v = base.Vector2D.from_direction(Direction.DRUP, 1)
         self.assertEqual(v, base.Vector2D(-1, 1))
-        v = base.Vector2D.from_direction(base.constants.DRDOWN, 1)
+        v = base.Vector2D.from_direction(Direction.DRDOWN, 1)
         self.assertEqual(v, base.Vector2D(1, 1))
-        v = base.Vector2D.from_direction(base.constants.DLUP, 1)
+        v = base.Vector2D.from_direction(Direction.DLUP, 1)
         self.assertEqual(v, base.Vector2D(-1, -1))
-        v = base.Vector2D.from_direction(base.constants.DLDOWN, 1)
+        v = base.Vector2D.from_direction(Direction.DLDOWN, 1)
         self.assertEqual(v, base.Vector2D(1, -1))
 
     def test_text(self):


### PR DESCRIPTION
# Switch to enums instead of int literals for constants

## Description

Switched internal references to these enums in all classes of the library.
Kept all the tests untouched (for compatibility), except for test_base.py that was referencing constants through base instead of importing the constants...

Fixes #219

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] All existing passes

**Test Configuration**:
* OS: Pop_OS
* OS version: 22.04
* Python version: 3.10.12
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes