### PR TITLE
Cache the board items position vector.

### DIFF
--- a/pygamelib/board_items.py
+++ b/pygamelib/board_items.py
@@ -140,6 +140,7 @@ class BoardItem(base.PglBaseObject):
         self.type = "item"
         if item_type is not None:
             self.type = item_type
+        self.__position_vector = base.Vector2D()
         self.pos = [None, None, None]
         if (
             pos is not None
@@ -148,6 +149,8 @@ class BoardItem(base.PglBaseObject):
             and pos[1] is not None
         ):
             self.pos = pos
+            self.__position_vector.row = pos[0]
+            self.__position_vector.column = pos[1]
         # DEPRECATED
         # self.model = "*"
         self._particle_emitter = None
@@ -421,6 +424,8 @@ class BoardItem(base.PglBaseObject):
             self.__centroidcc.column = column + self.width / 2
             self.__heading.row = self.__centroidcc.row - pcr
             self.__heading.column = self.__centroidcc.column - pcc
+            self.__position_vector.row = row
+            self.__position_vector.column = column
         if self.particle_emitter is not None:
             self.particle_emitter.row = row
             self.particle_emitter.column = column
@@ -436,7 +441,8 @@ class BoardItem(base.PglBaseObject):
             gravity = Vector2D(9.81, 0)
             next_position = item.position_as_vector() + gravity.unit()
         """
-        return base.Vector2D(self.pos[0], self.pos[1])
+        # return base.Vector2D(self.pos[0], self.pos[1])
+        return self.__position_vector
 
     @property
     def row(self):


### PR DESCRIPTION
Fixes #235

# Cache the board items position vector.

## Description

Changed the BoardItem.position_as_vector() function to return a cached version of the position vector instead of creating a new vector each time.

Fixes #235

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Existing test suite

**Test Configuration**:
* OS: Pop_OS
* OS version: 22.04
* Python version: 3.10.12
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes