### PR TITLE
 On certain OS, files are not opened using UTF8 by default

### DIFF
--- a/pygamelib/engine.py
+++ b/pygamelib/engine.py
@@ -2144,7 +2144,7 @@ class Game(base.PglBaseObject):
         if section not in self._configuration_internals:
             self._configuration_internals[section] = {}
 
-        with open(filename) as config_file:
+        with open(filename, "r", encoding="utf-8") as config_file:
             config_content = json.load(config_file)
             if section not in self._configuration.keys():
                 self._configuration[section] = config_content
@@ -2227,7 +2227,7 @@ class Game(base.PglBaseObject):
         mode = "w"
         if append:
             mode = "a"
-        with open(filename, mode) as file:
+        with open(filename, mode, encoding="utf-8") as file:
             json.dump(self._configuration[section], file)
 
     def add_board(self, level_number: int, board: Board) -> None:
@@ -3100,7 +3100,7 @@ class Game(base.PglBaseObject):
             game.change_level( 1 )
         """
         data = dict()
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding="utf-8") as f:
             data = json.load(f)
         local_board = None
         if "data_version" in data.keys() and data["data_version"] >= 2:
@@ -3247,7 +3247,7 @@ class Game(base.PglBaseObject):
             for o in self.object_library:
                 data["library"].append(o.serialize())
 
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             json.dump(data, f)
 
     def start(self):

--- a/pygamelib/gfx/core.py
+++ b/pygamelib/gfx/core.py
@@ -1276,7 +1276,7 @@ class Sprite(base.PglBaseObject):
         if default_sprixel is None:
             default_sprixel = Sprixel(" ", None, None)
         new_sprite = cls(default_sprixel=default_sprixel)
-        with open(filename, "r") as sprite_file:
+        with open(filename, "r", encoding="utf-8") as sprite_file:
             zero = sprite_file.tell()
             line = sprite_file.readline()
             parser_mode = 0
@@ -1803,7 +1803,7 @@ class SpriteCollection(UserDict):
 
             sprites_village1 = SpriteCollection.load_json_file('gfx/village1.spr')
         """
-        with open(filename) as sprites_file:
+        with open(filename, "r", encoding="utf-8") as sprites_file:
             sprites_data = json.load(sprites_file)
             return SpriteCollection.load(sprites_data)
 
@@ -1838,7 +1838,7 @@ class SpriteCollection(UserDict):
 
             sprites_village1.to_json_file('gfx/village1.spr')
         """
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             json.dump(self.serialize(), file)
 
     def add(self, sprite):
@@ -2491,7 +2491,7 @@ class Font:
                 break
         # This will throw a FileNotFoundError if the font is not present.
         self.__sprite_collection = SpriteCollection.load_json_file(glyphs_path)
-        with open(config_path) as config_file:
+        with open(config_path, "r", encoding="utf-8") as config_file:
             self.__config = json.load(config_file)
         self.__config["fg_color"] = Color.load(self.__config["fg_color"])
         self.__config["bg_color"] = Color.load(self.__config["bg_color"])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     print("Please install pipenv first. See: https://github.com/pypa/pipenv")
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 # Compatibility layer between Pipenv and Pip requirements.txt


### PR DESCRIPTION
# Fix for utf-8 not being enforced in all call to open()

## Description

This PR is very simple: in every call to open(), the utf-8 encoding is now explicitely forced.

Fixes #253

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local tests
- [x] Run the test suite

**Test Configuration**:
* OS: Tuxedo
* OS version: 22.04
* Python version: 3.10.12
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
