### PR TITLE
Fix the missing files in the font assets bug

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include pygamelib/assets/fonts/*/config.json
+include pygamelib/assets/fonts/*/glyphs.spr
+include pygamelib/assets/fonts/*/Readme.md

--- a/pygamelib/constants.py
+++ b/pygamelib/constants.py
@@ -9,7 +9,7 @@ Starting with version 1.4.0, all constants must be an Enum.
 """
 
 # Main version
-PYGAMELIB_VERSION = "1.3.0"
+PYGAMELIB_VERSION = "1.3.1"
 
 # Directions
 NO_DIR = 10000000

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
 # Compatibility layer between Pipenv and Pip requirements.txt
 # See https://github.com/pypa/pipenv/issues/209
 pipfile = Project(chdir=False).parsed_pipfile
-requirements_path = convert_deps_to_pip(pipfile["packages"])
+requirements = convert_deps_to_pip(pipfile["packages"])
 
-INSTALL_PACKAGES = open(requirements_path).read().splitlines()
+INSTALL_PACKAGES = list(requirements.values())
+
 
 setuptools.setup(
     name="pygamelib",
@@ -28,6 +29,8 @@ setuptools.setup(
     install_requires=INSTALL_PACKAGES,
     url="https://www.pygamelib.org",
     packages=setuptools.find_packages(),
+    include_package_data=True,
+    zip_safe=False,
     scripts=["pgl-editor.py", "pgl-board-tester.py", "pgl-sprite-editor.py"],
     keywords=["game", "development", "beginner", "console", "terminal"],
     classifiers=[


### PR DESCRIPTION
# Fix the missing files in the font assets bug

## Description

Fix a pipenv change related issue in setup.py
Add a MANIFEST.in to include the data files required by the fonts.
Fix setup.py to include extra package data.
Set library version to 1.3.1.

Fixes #256

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local tests
- [x] Test suite

**Test Configuration**:
* OS: Tuxedo Linux
* OS version: 22.04
* Python version: 3.10.12
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
